### PR TITLE
[bugfix] Pin EdgeDriver version to `127.0.2651.87` for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,6 @@ jobs:
     outputs:
       artifact-id: ${{steps.upload-artifacts.outputs.artifact-id}}
       artifact-name: dist-${{inputs.build-config}}
-    env:
-      EDGEDRIVER_VERSION: '127.0.2651.86'
     steps:
       - id: checkout-repository
         name: Checkout repository
@@ -62,6 +60,8 @@ jobs:
         run: pnpm install
       - id: build
         name: Build
+        env:
+          EDGEDRIVER_VERSION: '127.0.2651.86'
         run: pnpm run build:${{inputs.build-config}}
       - id: upload-artifacts
         name: Upload artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,8 @@ jobs:
     outputs:
       artifact-id: ${{steps.upload-artifacts.outputs.artifact-id}}
       artifact-name: dist-${{inputs.build-config}}
+    env:
+      EDGEDRIVER_VERSION: '127.0.2651.86'
     steps:
       - id: checkout-repository
         name: Checkout repository

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,8 +60,6 @@ jobs:
         run: pnpm install
       - id: build
         name: Build
-        env:
-          EDGEDRIVER_VERSION: '127.0.2651.86'
         run: pnpm run build:${{inputs.build-config}}
       - id: upload-artifacts
         name: Upload artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      EDGEDRIVER_VERSION: '127.0.2651.86'
     steps:
       - id: checkout-repository
         name: Checkout repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      EDGEDRIVER_VERSION: '127.0.2651.86'
+      EDGEDRIVER_VERSION: '127.0.2651.87'
     steps:
       - id: checkout-repository
         name: Checkout repository


### PR DESCRIPTION
Gets test workflow passing again in the short term.