### PR TITLE
[chore] Adjust coverage config in Vitest

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,27 @@ export default defineConfig({
             enabled: true,
             all: true,
             provider: 'istanbul',
-            reporter: ['text']
+            reporter: ['text'],
+            exclude: [
+                'scripts/**',
+                'templates/**',
+                'coverage/**',
+                'dist/**',
+                '**/[.]**',
+                'packages/*/test?(s)/**',
+                '**/*.d.ts',
+                '**/virtual:*',
+                '**/__x00__*',
+                '**/\x00*',
+                'cypress/**',
+                'test?(s)/**',
+                'test?(-*).?(c|m)[jt]s?(x)',
+                '**/*{.,-}{test,spec}?(-d).?(c|m)[jt]s?(x)',
+                '**/__tests__/**',
+                '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+                '**/vitest.{workspace,projects}.[jt]s?(on)',
+                '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}'
+            ]
         },
         passWithNoTests: true,
         reporters: 'default'


### PR DESCRIPTION
* Exclude `templates` folder from code coverage.
* Exclude `scripts` folder from code coverage.
* Exclude Vitest defaults from code coverage.