### PR TITLE
[Chore] Fix "Vitest unexpectedly reloaded" warnings

### DIFF
--- a/packages/logging/src/namespace.ts
+++ b/packages/logging/src/namespace.ts
@@ -334,6 +334,5 @@ export function match(
         ...options
     };
     const components = arrays.zip(toComponents(lhs), toComponents(rhs));
-    console.debug(components);
     return components.every(([lhs, rhs]) => componentsMatch(lhs, rhs, opts));
 }

--- a/packages/logging/tests/namespace.spec.ts
+++ b/packages/logging/tests/namespace.spec.ts
@@ -1411,9 +1411,6 @@ describe('module:namespace', (): void => {
             const lhs1 = m.fromComponents(...lhsComps1);
             const rhs1 = m.fromComponents(...rhsComps1);
 
-            console.debug(`LHS: ${lhs1}\n`);
-            console.debug(`RHS: ${rhs1}\n`);
-
             //-- When
             const r1 = m.match(lhs1, rhs1);
 
@@ -1488,9 +1485,6 @@ describe('module:namespace', (): void => {
             );
             const lhs1 = m.fromComponents(...lhsComps1);
             const rhs1 = m.fromComponents(...rhsComps1);
-
-            console.debug(`LHS: ${lhs1}\n`);
-            console.debug(`RHS: ${rhs1}\n`);
 
             //-- When
             const r1 = m.match(lhs1, rhs1);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'node:path';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
+    optimizeDeps: {
+        include: ['@faker-js/faker']
+    },
     test: {
         projects: [
             path.resolve(import.meta.dirname, './app/vite.config.ts'),


### PR DESCRIPTION
This was being caused by `@faker-js/faker` not being pre-optimized prior to tests being run.

Added `@faker-js/faker` to the `optimizeDeps.include` array.

Also removed some extraneous debug logging that got left behind in the current tests.